### PR TITLE
Support pausing the scaling or killing all dynos

### DIFF
--- a/rectifier/config/__init__.py
+++ b/rectifier/config/__init__.py
@@ -1,4 +1,4 @@
-from .config import AppConfig, CoordinatorConfig, QueueConfig, Config
+from .config import AppConfig, CoordinatorConfig, QueueConfig, Config, AppMode
 from .config_parser import ConfigParser, ConfigReadError
 
 __all__ = [
@@ -8,4 +8,5 @@ __all__ = [
     'Config',
     'ConfigParser',
     'ConfigReadError',
+    'AppMode',
 ]

--- a/rectifier/config/config.py
+++ b/rectifier/config/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Dict
 
 
@@ -13,11 +14,18 @@ class QueueConfig:
     consumers_formation_name: str
 
 
+class AppMode(Enum):
+    SCALE = 'scale'
+    NOOP = 'noop'
+    KILL = 'kill'
+
+
 @dataclass
 class AppConfig:
     """Configuration for a single App"""
 
     queues: Dict[str, QueueConfig]
+    mode: AppMode
 
 
 @dataclass
@@ -34,4 +42,4 @@ class Config:
     coordinator_config: CoordinatorConfig
 
 
-__all__ = ['QueueConfig', 'CoordinatorConfig', 'AppConfig', 'Config']
+__all__ = ['QueueConfig', 'CoordinatorConfig', 'AppConfig', 'Config', 'AppMode']

--- a/rectifier/config/config_parser.py
+++ b/rectifier/config/config_parser.py
@@ -6,7 +6,7 @@ import jsonschema
 import structlog
 
 import schemas
-from rectifier.config import Config, AppConfig, QueueConfig, CoordinatorConfig
+from rectifier.config import Config, AppConfig, QueueConfig, CoordinatorConfig, AppMode
 from rectifier.storage.storage import Storage
 from rectifier import settings
 
@@ -49,15 +49,16 @@ class ConfigParser:
         cls.validate(data)
 
         apps = dict()
-        for (app, queues_config) in data.items():
+        for (app, config) in data.items():
             queues = dict()
 
-            for (queue_name, queue_properties) in queues_config.items():
+            mode = AppMode(config.get('mode', AppMode.SCALE.value))
+            for (queue_name, queue_properties) in cls._queue_configs(config):
                 queues[queue_name] = QueueConfig(
                     queue_name=queue_name, **queue_properties
                 )
 
-            apps[app] = AppConfig(queues=queues)
+            apps[app] = AppConfig(queues=queues, mode=mode)
 
         return Config(coordinator_config=CoordinatorConfig(apps=apps))
 
@@ -78,8 +79,15 @@ class ConfigParser:
             LOGGER.error(message, config=data, err=err)
             raise ConfigReadError(message) from err
 
-        for (app, queues) in data.items():
-            for (queue_name, queue_properties) in queues.items():
+        for (app, config) in data.items():
+            app_mode = config.get('mode', AppMode.SCALE.value)
+            try:
+                AppMode(app_mode)
+            except ValueError:
+                message = f'Improper value for app mode: {app_mode}'
+                raise ConfigReadError(message)
+
+            for (queue_name, queue_properties) in cls._queue_configs(config):
                 intervals = queue_properties['intervals']
                 workers = queue_properties['workers']
                 cooldown = queue_properties['cooldown']
@@ -117,3 +125,7 @@ class ConfigParser:
                     message = 'The intervals should be sorted in ascending order.'
                     LOGGER.error(message, intervals=intervals, queue_name=queue_name)
                     raise ConfigReadError(message)
+
+    @staticmethod
+    def _queue_configs(app_config: Dict):
+        return ((k, v) for (k, v) in app_config.items() if k != 'mode')

--- a/rectifier/config/config_parser.py
+++ b/rectifier/config/config_parser.py
@@ -83,9 +83,9 @@ class ConfigParser:
             app_mode = config.get('mode', AppMode.SCALE.value)
             try:
                 AppMode(app_mode)
-            except ValueError:
-                message = f'Improper value for app mode: {app_mode}'
-                raise ConfigReadError(message)
+            except ValueError as err:
+                message = f'Improper value for app mode: {app_mode}. Possible values: {[mode.value for mode in AppMode]}'
+                raise ConfigReadError(message) from err
 
             for (queue_name, queue_properties) in cls._queue_configs(config):
                 intervals = queue_properties['intervals']

--- a/rectifier/consumer_updates_coordinator/consumer_updates_coordinator.py
+++ b/rectifier/consumer_updates_coordinator/consumer_updates_coordinator.py
@@ -75,8 +75,6 @@ class ConsumerUpdatesCoordinator:
             Otherwise
                 - the number of consumers which should be used for this queue.
         """
-        LOGGER.info("Computing the consumers count.", queue=queue)
-
         last_update = self.queues_update_time[app].get(queue.queue_name)
 
         queue_config = self.config.apps[app].queues[queue.queue_name]
@@ -101,10 +99,6 @@ class ConsumerUpdatesCoordinator:
         consumers_for_interval = queue_config.workers[matching_interval_index]
 
         if queue.consumers_count == consumers_for_interval:
-            LOGGER.info(
-                "Nothing to do. Queue has the proper consumer count.",
-                consumer_cont=queue.consumers_count,
-            )
             return None, None
 
         self._update_time(app, queue.queue_name)

--- a/rectifier/consumer_updates_coordinator/consumer_updates_coordinator.py
+++ b/rectifier/consumer_updates_coordinator/consumer_updates_coordinator.py
@@ -6,7 +6,7 @@ from typing import DefaultDict, Dict, Optional, Tuple
 
 import structlog
 
-from rectifier.config import CoordinatorConfig
+from rectifier.config import CoordinatorConfig, AppMode
 from rectifier.queue import Queue
 from rectifier.storage import Storage
 from rectifier import settings
@@ -60,7 +60,7 @@ class ConsumerUpdatesCoordinator:
         )
 
     def compute_consumers_count(
-        self, app: str, queue: Queue
+        self, app: str, app_mode: AppMode, queue: Queue
     ) -> Tuple[Optional[int], Optional[str]]:
         """
         Computes the count of the consumers which should be used for a queue, given its stats and the configuration.
@@ -89,6 +89,12 @@ class ConsumerUpdatesCoordinator:
                     timedelta=time_since_update.seconds,
                 )
                 return None, None
+
+        if app_mode == AppMode.KILL:
+            return (
+                0 if queue.consumers_count else None,
+                queue_config.consumers_formation_name,
+            )
 
         matching_interval_index = [
             i

--- a/rectifier/infrastructure_provider/infrastructure_provider.py
+++ b/rectifier/infrastructure_provider/infrastructure_provider.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import Dict
 
 

--- a/rectifier/rectifier.py
+++ b/rectifier/rectifier.py
@@ -91,14 +91,8 @@ class Rectifier:
 
             updates = dict()
             for queue in queues:
-                if app_config.mode == AppMode.KILL:
-                    updates[
-                        queues_config[queue.queue_name].consumers_formation_name
-                    ] = 0
-                    continue
-
                 new_consumer_count, consumer_formation = self.consumer_updates_coordinator.compute_consumers_count(
-                    app, queue
+                    app, app_config.mode, queue
                 )
 
                 if new_consumer_count is None:

--- a/rectifier/rectifier.py
+++ b/rectifier/rectifier.py
@@ -3,7 +3,7 @@ from typing import Optional
 import structlog
 
 from rectifier import settings
-from rectifier.config import ConfigParser
+from rectifier.config import ConfigParser, AppMode
 from rectifier.consumer_updates_coordinator import ConsumerUpdatesCoordinator
 from rectifier.infrastructure_provider import (
     InfrastructureProvider,
@@ -76,6 +76,9 @@ class Rectifier:
             return
 
         for (app, app_config) in self.consumer_updates_coordinator.config.apps.items():
+            if app_config.mode == AppMode.NOOP:
+                continue
+
             queues_config = app_config.queues
 
             broker_uri = self.infrastructure_provider.broker_uri(app)
@@ -88,6 +91,12 @@ class Rectifier:
 
             updates = dict()
             for queue in queues:
+                if app_config.mode == AppMode.KILL:
+                    updates[
+                        queues_config[queue.queue_name].consumers_formation_name
+                    ] = 0
+                    continue
+
                 new_consumer_count, consumer_formation = self.consumer_updates_coordinator.compute_consumers_count(
                     app, queue
                 )

--- a/rectifier/settings.py
+++ b/rectifier/settings.py
@@ -24,7 +24,7 @@ HEROKU_API_KEYS = env.list(
 )
 
 HOST = env('HOST', '0.0.0.0')
-PORT = env.int('PORT', 3008)
+PORT = env.int('PORT', 80)
 
 BASIC_AUTH_USER = env('BASIC_AUTH_USER', 'guest')
 BASIC_AUTH_PASSWORD = env('BASIC_AUTH_PASSWORD', 'guest')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ black==18.9b0
 certifi==2018.8.24
 chardet==3.0.4
 Click==7.0
+colorama==0.4.3
 coverage==4.5.1
 environ==1.0
 environs==4.0.0
@@ -16,6 +17,7 @@ freezegun==0.3.10
 gunicorn==19.9.0
 heroku3==4.2.1
 idna==2.7
+importlib-metadata==1.6.0
 itsdangerous==0.24
 Jinja2==2.11.1
 jsonschema==3.2.0
@@ -23,12 +25,14 @@ MarkupSafe==1.1.1
 marshmallow==3.5.0
 more-itertools==4.3.0
 mypy==0.630
+mypy-extensions==0.4.3
 pika==0.12.0
 pluggy==0.7.1
 py==1.6.0
+pyrsistent==0.16.0
 pytest==3.8.1
 pytest-cov==2.6.0
-python-dateutil==2.8.1
+python-dateutil==2.6.0
 python-dotenv==0.9.1
 pytz==2018.5
 redis==2.10.6
@@ -37,8 +41,8 @@ simplejson==3.3.1
 six==1.11.0
 structlog==18.2.0
 toml==0.10.0
+typed-ast==1.4.1
 tzlocal==1.5.1
 urllib3==1.24.2
 Werkzeug==1.0.0
-typed-ast==1.4.1
-colorama==0.4.3
+zipp==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ tzlocal==1.5.1
 urllib3==1.24.2
 Werkzeug==1.0.0
 typed-ast==1.4.1
+colorama==0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ redis==2.10.6
 requests==2.20.0
 simplejson==3.3.1
 six==1.11.0
-structlog==18.2.0
+structlog==20.1.0
 toml==0.10.0
 typed-ast==1.4.1
 tzlocal==1.5.1

--- a/schemas/config.py
+++ b/schemas/config.py
@@ -13,8 +13,10 @@ class Config:
 
     APP = {
         'type': 'object',
-        'patternProperties': {'.*': QUEUE},
-        'additionalProperties': False,
+        'patternProperties': {
+            '^(?!mode).*$': QUEUE,
+            '^mode$': {'type': 'string', 'enum': ['scale', 'noop', 'kill']},
+        },
     }
 
     SCHEMA = {

--- a/static/schema.js
+++ b/static/schema.js
@@ -1,0 +1,51 @@
+window.schema = {
+    "type": "object",
+    "patternProperties": {
+        ".*": {
+            "type": "object",
+            "patternProperties": {
+                "^(?!mode).*$": {
+                    "type": "object",
+                    "properties": {
+                        "intervals": {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        "workers": {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        "cooldown": {
+                            "type": "number"
+                        },
+                        "consumers_formation_name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "intervals",
+                        "workers",
+                        "cooldown",
+                        "consumers_formation_name"
+                    ],
+                    "additionalProperties": false
+                },
+                "^mode$": {
+                    "type": "string",
+                    "enum": [
+                        "scale",
+                        "noop",
+                        "kill"
+                    ]
+                }
+            }
+        }
+    },
+    "additionalProperties": false
+};
+
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -130,7 +130,10 @@
             </form>
         </div>
 
+        <script src="{{ url_for('static', filename='schema.js') }}"></script>
         <script type="text/javascript">
+            let errors = [];
+
             const onChangeText = (code) => {
                 let isJSONValid = false;
 
@@ -140,7 +143,12 @@
                 } catch {}
 
                 document.configForm.code.value = code;
-                document.configForm.submit.disabled = !isJSONValid;
+                document.configForm.submit.disabled = !isJSONValid || errors.length > 0;
+            };
+
+            const onValidationError = (newErrors) => {
+                errors = newErrors;
+                document.configForm.submit.disabled = errors.length > 0;
             };
 
             const container = document.getElementById("code");
@@ -148,6 +156,8 @@
                 onChangeText,
                 modes: ['code', 'tree'],
                 mode: 'code',
+                schema: window.schema,
+                onValidationError,
             });
 
             editor.set({{  config|safe }});

--- a/tests/env.py
+++ b/tests/env.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rectifier import settings
-from rectifier.config import Config, CoordinatorConfig, QueueConfig, AppConfig
+from rectifier.config import Config, CoordinatorConfig, QueueConfig, AppConfig, AppMode
 
 from .rabbitmq_mock import RabbitMQAPIMock
 
@@ -15,7 +15,8 @@ class TestableEnv:
 
         apps = dict(
             rectifier=AppConfig(
-                dict(
+                mode=AppMode.SCALE,
+                queues=dict(
                     queue=QueueConfig(
                         intervals=[1, 10, 20, 30],
                         workers=[1, 5, 50, 500],
@@ -23,7 +24,7 @@ class TestableEnv:
                         queue_name='queue',
                         consumers_formation_name='worker_queue',
                     )
-                )
+                ),
             )
         )
 

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -7,13 +7,14 @@ from rectifier.config import (
     CoordinatorConfig,
     QueueConfig,
 )
-from rectifier.config.config import AppConfig
+from rectifier.config.config import AppConfig, AppMode
 from tests.redis_mock import RedisStorageMock
 
 
 def test_config_reader_dict_parsing():
     config = {
         'rectifier': {
+            'mode': 'noop',
             'q1': {
                 'intervals': [0, 10, 20, 30],
                 'workers': [1, 5, 50, 500],
@@ -40,6 +41,7 @@ def test_config_reader_dict_parsing():
         coordinator_config=CoordinatorConfig(
             apps=dict(
                 rectifier=AppConfig(
+                    mode=AppMode.NOOP,
                     queues=dict(
                         q1=QueueConfig(
                             intervals=[0, 10, 20, 30],
@@ -55,9 +57,10 @@ def test_config_reader_dict_parsing():
                             queue_name='q2',
                             consumers_formation_name='q2w',
                         ),
-                    )
+                    ),
                 ),
                 rectifier2=AppConfig(
+                    mode=AppMode.SCALE,
                     queues=dict(
                         q3=QueueConfig(
                             intervals=[0, 10, 11, 12],
@@ -66,7 +69,7 @@ def test_config_reader_dict_parsing():
                             queue_name='q3',
                             consumers_formation_name='q3w',
                         )
-                    )
+                    ),
                 ),
             )
         )
@@ -83,6 +86,7 @@ def test_config_reader():
         coordinator_config=CoordinatorConfig(
             apps=dict(
                 rectifier=AppConfig(
+                    mode=AppMode.SCALE,
                     queues=dict(
                         q1=QueueConfig(
                             intervals=[0, 10, 20, 30],
@@ -91,9 +95,10 @@ def test_config_reader():
                             queue_name='q1',
                             consumers_formation_name='worker_rectifier',
                         )
-                    )
+                    ),
                 ),
                 rectifier2=AppConfig(
+                    mode=AppMode.SCALE,
                     queues=dict(
                         q21=QueueConfig(
                             intervals=[0, 10, 22, 85],
@@ -102,7 +107,7 @@ def test_config_reader():
                             queue_name='q21',
                             consumers_formation_name='worker_rectifier2',
                         )
-                    )
+                    ),
                 ),
             )
         )

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,3 +1,4 @@
+import pytest
 import pickle
 from collections import defaultdict
 from typing import Dict
@@ -5,6 +6,7 @@ from typing import Dict
 from freezegun import freeze_time
 
 from rectifier import settings
+from rectifier.config import AppMode
 from rectifier.infrastructure_provider import InfrastructureProvider
 from rectifier.message_brokers import RabbitMQ
 from rectifier.rectifier import Rectifier
@@ -125,6 +127,36 @@ def test_monitor(env):
         assert infrastructure_provider.called_count == 7
         assert infrastructure_provider.consumers['rectifier']['worker_q1'] == 1
         assert infrastructure_provider.consumers['rectifier2']['worker_q2'] == 2
+
+
+@pytest.mark.parametrize(
+    'mode, expected_called_count, expected_workers',
+    [
+        (AppMode.SCALE.value, 1, 3),
+        (AppMode.KILL.value, 1, 0),
+        (AppMode.NOOP.value, 0, 0),
+    ],
+)
+def test_monitor_paused(env, mode, expected_called_count, expected_workers):
+    storage = RedisStorageMock()
+    infrastructure_provider = InfrastructureProviderMock(env)
+
+    config = f'{{"rectifier":{{"mode": "{mode}", "q1":{{"intervals":[0,10,100],"workers":[1,2,3],"cooldown":60,"consumers_formation_name":"worker_q1"}}}}}}'
+    storage.set(settings.REDIS_CONFIG_KEY, bytes(config, 'utf-8'))
+
+    rectifier = Rectifier(
+        broker=RabbitMQ(),
+        storage=storage,
+        infrastructure_provider=infrastructure_provider,
+    )
+
+    env.rabbitmq.set_queue('rectifier', 'q1', 10, 200)
+    rectifier.run()
+
+    assert infrastructure_provider.called_count == expected_called_count
+    assert (
+        infrastructure_provider.consumers['rectifier']['worker_q1'] == expected_workers
+    )
 
 
 def test_monitor_with_no_config(env):

--- a/tests/test_rabbitmq_stats.py
+++ b/tests/test_rabbitmq_stats.py
@@ -45,8 +45,7 @@ def test_get_current_load_missing_queue(env):
     that doesn't exists doesn't make things crash."""
 
     interest_queues = RabbitMQ.queues(
-        ["byebyequeue"],
-        RabbitMQ.stats(env.rabbit_mq_uri(app='myapp')),
+        ["byebyequeue"], RabbitMQ.stats(env.rabbit_mq_uri(app='myapp'))
     )
 
     assert len(interest_queues) == 0


### PR DESCRIPTION
This introduces the support for the concept of app _running_ mode. Which can be:

* Not specified: works as before, in the `scale` mode
* `scale`: scales dynos according to the configuration
* `noop`: doesn't do anything for the current app, no matter the configuration or queues
* `kill`: sets the workers count to 0 for all the queues defined in the configuration